### PR TITLE
Optional IHistoryTransform added to ChatSession.InitializeSessionFromHistoryAsync

### DIFF
--- a/LLama/ChatSession.cs
+++ b/LLama/ChatSession.cs
@@ -74,15 +74,21 @@ public class ChatSession
     /// </summary>
     /// <param name="executor">The executor for this session</param>
     /// <param name="history">History for this session</param>
-    /// <returns></returns>
+    /// <param name="transform">History Transform for this session</param>
+    /// <returns>A new chat session.</returns>
     public static async Task<ChatSession> InitializeSessionFromHistoryAsync(
-        ILLamaExecutor executor, ChatHistory history)
+        ILLamaExecutor executor, ChatHistory history, IHistoryTransform? transform = null)
     {
         if (executor is not StatefulExecutorBase statefulExecutor)
         {
             throw new ArgumentException("Executor must have a StatefulExecutorBase", nameof(executor));
         }
         var session = new ChatSession(executor, history);
+        if (transform != null)
+        {
+            session = session.WithHistoryTransform(transform);
+        }
+
         await statefulExecutor.PrefillPromptAsync(session.HistoryTransform.HistoryToText(history));
         return session;
     }


### PR DESCRIPTION
This pull request introduces an optional parameter, `IHistoryTransform? transform`, to the `InitializeSessionFromHistoryAsync` method in the `ChatSession` class. This change accommodates models that require specific formatting of the chat history.

Some language models may require the chat history to be formatted in a specific way before being passed to the model for generating a response. The addition of the `IHistoryTransform` parameter allows for the flexibility to apply custom transformations to the chat history when initializing a new session.

This change maintains backward compatibility with existing code that does not provide a custom history transform by making the `transform` parameter optional and defaulting it to `null`.

